### PR TITLE
[deps] fix: update deps

### DIFF
--- a/recipes/benchmark/all/test_package/CMakeLists.txt
+++ b/recipes/benchmark/all/test_package/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_VERBOSE_MAKEFILE TRUE)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
-find_package(benchmark 1.7.0 EXACT REQUIRED)
+find_package(benchmark 1.7.1 EXACT REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} benchmark::benchmark)

--- a/recipes/benchmark/config.yml
+++ b/recipes/benchmark/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "1.7.0":
+  "1.7.1":
     folder: all

--- a/recipes/cppzmq/all/conandata.yml
+++ b/recipes/cppzmq/all/conandata.yml
@@ -1,14 +1,14 @@
 sources:
-  "4.7.1":
-    url: "https://github.com/zeromq/cppzmq/archive/v4.7.1.tar.gz"
-    sha256: "9853e0437d834cbed5d3c223bf1d755cadee70e7c964c6e42c4c6783dee5d02c"
   "4.8.1":
     url: "https://github.com/zeromq/cppzmq/archive/v4.8.1.tar.gz"
     sha256: "7a23639a45f3a0049e11a188e29aaedd10b2f4845f0000cf3e22d6774ebde0af"
+  "4.9.0":
+    url: "https://github.com/zeromq/cppzmq/archive/v4.9.0.tar.gz"
+    sha256: "3fdf5b100206953f674c94d40599bdb3ea255244dcc42fab0d75855ee3645581"
 patches:
-  "4.7.1":
+  "4.8.1":
     - base_path: "source_subfolder"
       patch_file: "patches/0002-cmakelists-hacks.patch"
-  "4.8.1":
+  "4.9.0":
     - base_path: "source_subfolder"
       patch_file: "patches/0002-cmakelists-hacks.patch"

--- a/recipes/cppzmq/config.yml
+++ b/recipes/cppzmq/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "4.8.1":
+  "4.9.0":
     folder: all

--- a/recipes/mongo-c-driver/all/conandata.yml
+++ b/recipes/mongo-c-driver/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "1.17.5":
-    url: https://github.com/mongodb/mongo-c-driver/releases/download/1.17.5/mongo-c-driver-1.17.5.tar.gz
-    sha256: 4b15b7e73a8b0621493e4368dc2de8a74af381823ae8f391da3d75d227ba16be
   "1.22.0":
     url: https://github.com/mongodb/mongo-c-driver/releases/download/1.22.0/mongo-c-driver-1.22.0.tar.gz
     sha256: 272067f75e7e57c98f90a6f0c42500ef818b4b085539343676b6ce6831655eaf
+  "1.22.2":
+    url: https://github.com/mongodb/mongo-c-driver/releases/download/1.22.2/mongo-c-driver-1.22.2.tar.gz
+    sha256: 2e59b9d38d600bd63ccc0b215dd44c6254a66eeb8085a5ac513748cd6220532e

--- a/recipes/mongo-c-driver/all/conandata.yml
+++ b/recipes/mongo-c-driver/all/conandata.yml
@@ -2,6 +2,6 @@ sources:
   "1.22.0":
     url: https://github.com/mongodb/mongo-c-driver/releases/download/1.22.0/mongo-c-driver-1.22.0.tar.gz
     sha256: 272067f75e7e57c98f90a6f0c42500ef818b4b085539343676b6ce6831655eaf
-  "1.22.2":
-    url: https://github.com/mongodb/mongo-c-driver/releases/download/1.22.2/mongo-c-driver-1.22.2.tar.gz
-    sha256: 2e59b9d38d600bd63ccc0b215dd44c6254a66eeb8085a5ac513748cd6220532e
+  "1.23.1":
+    url: https://github.com/mongodb/mongo-c-driver/releases/download/1.23.1/mongo-c-driver-1.23.1.tar.gz
+    sha256: e1e4f59713b2e48dba1ed962bc0e52b00479b009a9ec4e5fbece61bda76a42df

--- a/recipes/mongo-c-driver/all/conanfile.py
+++ b/recipes/mongo-c-driver/all/conanfile.py
@@ -27,7 +27,7 @@ class MongoCDriverConan(ConanFile):
 
     def requirements(self):
         if self.settings.os == "Linux":
-            self.requires("openssl/1.1.1q@nemtech/stable")
+            self.requires("openssl/3.0.7")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])

--- a/recipes/mongo-c-driver/all/test_package/CMakeLists.txt
+++ b/recipes/mongo-c-driver/all/test_package/CMakeLists.txt
@@ -6,11 +6,13 @@ conan_basic_setup()
 
 find_package(libmongoc-1.0 REQUIRED)
 find_package(libbson-1.0 REQUIRED)
+find_package(ZLIB REQUIRED)
 
 message ("--   mongoc found version \"${MONGOC_VERSION}\"")
 message ("--   mongoc include path \"${MONGOC_INCLUDE_DIRS}\"")
 message ("--   mongoc libraries \"${MONGOC_LIBRARIES}\"")
+message ("--   zlib libraries \"${ZLIB_LIBRARIES}\"")
 
-include_directories(SYSTEM ${MONGOC_INCLUDE_DIRS})
+include_directories(SYSTEM ${MONGOC_INCLUDE_DIRS} ${ZLIB_INCLUDE_DIRS})
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${MONGOC_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${MONGOC_LIBRARIES} ${ZLIB_LIBRARIES})

--- a/recipes/mongo-c-driver/all/test_package/conanfile.py
+++ b/recipes/mongo-c-driver/all/test_package/conanfile.py
@@ -11,6 +11,10 @@ class TestPackageConan(ConanFile):
         cmake.configure()
         cmake.build()
 
+    def requirements(self):
+        if self.settings.os == "Linux":
+            self.requires("zlib/[~=1.2.13]")
+
     def test(self):
         if not tools.cross_building(self.settings):
             bin_path = os.path.join("bin", "test_package")

--- a/recipes/mongo-c-driver/config.yml
+++ b/recipes/mongo-c-driver/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "1.22.2":
+  "1.23.1":
     folder: all

--- a/recipes/mongo-c-driver/config.yml
+++ b/recipes/mongo-c-driver/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "1.22.0":
+  "1.22.2":
     folder: all

--- a/recipes/mongo-cxx-driver/all/conandata.yml
+++ b/recipes/mongo-cxx-driver/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "3.6.3":
-    url: https://github.com/mongodb/mongo-cxx-driver/archive/r3.6.3.tar.gz
-    sha256: bdf6033ed23df0cdd8c6e1e45cf6dfa63c9806893718eadfa6574cb25b3183a8
   "3.6.7":
     url: https://github.com/mongodb/mongo-cxx-driver/archive/r3.6.7.tar.gz
     sha256: a9244d3117d4029a2f039dece242eef10e34502e4600e2afa968ab53589e6de7
+  "3.7.0":
+    url: https://github.com/mongodb/mongo-cxx-driver/archive/r3.7.0.tar.gz
+    sha256: dbe9e2e973d234ac1acd1bdb2581f960b72b2a753a5cd13b7be5d5cdd8e63791

--- a/recipes/mongo-cxx-driver/all/conanfile.py
+++ b/recipes/mongo-cxx-driver/all/conanfile.py
@@ -18,7 +18,7 @@ class MongoCxxConan(ConanFile):
 
     _source_subfolder = "source_subfolder"
 
-    requires = 'mongo-c-driver/[~=1.22]@nemtech/stable'
+    requires = 'mongo-c-driver/[~=1.22.2]@nemtech/stable'
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])

--- a/recipes/mongo-cxx-driver/all/conanfile.py
+++ b/recipes/mongo-cxx-driver/all/conanfile.py
@@ -18,7 +18,7 @@ class MongoCxxConan(ConanFile):
 
     _source_subfolder = "source_subfolder"
 
-    requires = 'mongo-c-driver/[~=1.22.2]@nemtech/stable'
+    requires = 'mongo-c-driver/[~=1.23.1]@nemtech/stable'
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])

--- a/recipes/mongo-cxx-driver/config.yml
+++ b/recipes/mongo-cxx-driver/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "3.6.7":
+  "3.7.0":
     folder: all

--- a/recipes/rocksdb/all/conandata.yml
+++ b/recipes/rocksdb/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "6.20.3":
-    url: https://github.com/facebook/rocksdb/archive/v6.20.3.tar.gz
-    sha256: c6502c7aae641b7e20fafa6c2b92273d935d2b7b2707135ebd9a67b092169dca
   "7.4.3":
     url: https://github.com/facebook/rocksdb/archive/v7.4.3.tar.gz
     sha256: ca1fedc931d2232603a84db6120b6e9158bc1f14ef113291624dc357500e48ab
+  "7.7.3":
+    url: https://github.com/facebook/rocksdb/archive/v7.7.3.tar.gz
+    sha256: b8ac9784a342b2e314c821f6d701148912215666ac5e9bdbccd93cf3767cb611

--- a/recipes/rocksdb/config.yml
+++ b/recipes/rocksdb/config.yml
@@ -1,4 +1,4 @@
 ---
 versions:
-  "7.4.3":
+  "7.7.3":
     folder: all


### PR DESCRIPTION
Update the following deps:
1. rocksdb to 7.7.3
2. benchmark to 1.7.1
3. mongo-c-driver to 1.22.2
4. mongo-cxx-driver to 3.7.0
5. cppzmq to 4.9.0

Added zlib dependency to mongo-c-driver test due to the openssl update to 3.0.7 remove it.