### PR TITLE
[deps] fix: ARM support for rocksdb and benchmark

### DIFF
--- a/recipes/benchmark/all/conanfile.py
+++ b/recipes/benchmark/all/conanfile.py
@@ -57,7 +57,8 @@ class BenchmarkConan(ConanFile):
                 cmake.definitions["HAVE_POSIX_REGEX"] = False
                 cmake.definitions["HAVE_STEADY_CLOCK"] = False
             else:
-                cmake.definitions["BENCHMARK_BUILD_32_BITS"] = "ON" if "64" not in str(self.settings.arch) else "OFF"
+                cmake.definitions["BENCHMARK_BUILD_32_BITS"] = ("OFF" if "64" in str(self.settings.arch)
+                                                                       or 'armv8' == self.settings.arch else "ON")
             cmake.definitions["BENCHMARK_USE_LIBCXX"] = "ON" if (str(self.settings.compiler.libcxx) == "libc++") else "OFF"
         else:
             cmake.definitions["BENCHMARK_USE_LIBCXX"] = "OFF"

--- a/recipes/benchmark/all/conanfile.py
+++ b/recipes/benchmark/all/conanfile.py
@@ -42,6 +42,9 @@ class BenchmarkConan(ConanFile):
         if self.settings.os == "Windows" and self.options.shared:
             raise ConanInvalidConfiguration("Windows shared builds are not supported right now, see issue #639")
 
+    def is_arch_64_bit(self):
+        return "64" in str(self.settings.arch) or self.settings.arch in ["armv8", "armv8.3", "armv9"]
+
     def _configure_cmake(self):
         cmake = CMake(self)
 
@@ -57,8 +60,7 @@ class BenchmarkConan(ConanFile):
                 cmake.definitions["HAVE_POSIX_REGEX"] = False
                 cmake.definitions["HAVE_STEADY_CLOCK"] = False
             else:
-                cmake.definitions["BENCHMARK_BUILD_32_BITS"] = ("OFF" if "64" in str(self.settings.arch)
-                                                                       or 'armv8' == self.settings.arch else "ON")
+                cmake.definitions["BENCHMARK_BUILD_32_BITS"] = "OFF" if self.is_arch_64_bit() else "ON"
             cmake.definitions["BENCHMARK_USE_LIBCXX"] = "ON" if (str(self.settings.compiler.libcxx) == "libc++") else "OFF"
         else:
             cmake.definitions["BENCHMARK_USE_LIBCXX"] = "OFF"

--- a/recipes/rocksdb/all/conanfile.py
+++ b/recipes/rocksdb/all/conanfile.py
@@ -89,6 +89,9 @@ class RocksDB(ConanFile):
         #cmake.definitions["ROCKSDB_DLL" ] = self.settings.os == "Windows" and self.options.shared
 
         cmake.definitions["USE_RTTI"] = self.options.use_rtti
+        if "arm" in str(self.settings.arch):
+            self.options.enable_sse = "False"
+
         if self.options.enable_sse == "False":
           cmake.definitions["PORTABLE"] = True
           cmake.definitions["FORCE_SSE42"] = False


### PR DESCRIPTION
problem: Rocksdb and benchmark failed to compile on ARM64 env.
         Rocks failed to compile since the 'sse42' is enabled by default which is not supported by ARM
         Benchmark failed to compile on ARM64 with gcc due it tried to compile in 32bit
solution: Add support for ARM environment
          RocksDB disable 'sse' feature
          Benchmark builds in 64bit for ARMv8