### PR TITLE
[recipe] fix: add support for Jenkins job to update recipes

### DIFF
--- a/.github/jenkinsfile/recipeUpdater.groovy
+++ b/.github/jenkinsfile/recipeUpdater.groovy
@@ -1,0 +1,7 @@
+gitPullRequestPipeline {
+	dockerImageName = 'symbolplatform/build-ci:cpp-ubuntu-lts'
+	branchName = 'fix/update_catapult_recipe'
+	scriptSetupCommand = 'python3 -m pip install -r scripts/requirements.txt'
+	scriptCommand = 'python3 scripts/CatapultRecipeUpdater.py --recipes-path recipes --commit-title "[recipe] fix: update recipes"'
+	reviewers = []
+}

--- a/.github/jenkinsfile/recipeUpdater.groovy
+++ b/.github/jenkinsfile/recipeUpdater.groovy
@@ -1,6 +1,6 @@
 gitPullRequestPipeline {
 	dockerImageName = 'symbolplatform/build-ci:cpp-ubuntu-lts'
-	branchName = 'fix/update_catapult_recipe'
+	prBranchName = 'fix/update_catapult_recipe'
 	scriptSetupCommand = 'python3 -m pip install -r scripts/requirements.txt'
 	scriptCommand = 'python3 scripts/CatapultRecipeUpdater.py --recipes-path recipes --commit-title "[recipe] fix: update recipes"'
 	reviewers = []

--- a/recipes/cppzmq/all/conandata.yml
+++ b/recipes/cppzmq/all/conandata.yml
@@ -1,14 +1,8 @@
 sources:
-  "4.8.1":
-    url: "https://github.com/zeromq/cppzmq/archive/v4.8.1.tar.gz"
-    sha256: "7a23639a45f3a0049e11a188e29aaedd10b2f4845f0000cf3e22d6774ebde0af"
   "4.9.0":
     url: "https://github.com/zeromq/cppzmq/archive/v4.9.0.tar.gz"
     sha256: "3fdf5b100206953f674c94d40599bdb3ea255244dcc42fab0d75855ee3645581"
 patches:
-  "4.8.1":
-    - base_path: "source_subfolder"
-      patch_file: "patches/0002-cmakelists-hacks.patch"
   "4.9.0":
     - base_path: "source_subfolder"
       patch_file: "patches/0002-cmakelists-hacks.patch"

--- a/recipes/mongo-c-driver/all/conandata.yml
+++ b/recipes/mongo-c-driver/all/conandata.yml
@@ -1,7 +1,4 @@
 sources:
-  "1.22.0":
-    url: https://github.com/mongodb/mongo-c-driver/releases/download/1.22.0/mongo-c-driver-1.22.0.tar.gz
-    sha256: 272067f75e7e57c98f90a6f0c42500ef818b4b085539343676b6ce6831655eaf
-  "1.23.2":
-    url: https://github.com/mongodb/mongo-c-driver/releases/download/1.23.2/mongo-c-driver-1.23.2.tar.gz
-    sha256: 123c358827eea07cd76a31c40281bb1c81b6744f6587c96d0cf217be8b1234e3
+  1.25.3:
+    url: "https://github.com/mongodb/mongo-c-driver/archive/refs/tags/1.25.3.tar.gz"
+    sha256: "d7cdedc5164b7b8ca39bb45bee789da44097052c882fa84996e4d90eec6fe8d3"

--- a/recipes/mongo-c-driver/all/conandata.yml
+++ b/recipes/mongo-c-driver/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  1.25.3:
-    url: "https://github.com/mongodb/mongo-c-driver/archive/refs/tags/1.25.3.tar.gz"
-    sha256: "d7cdedc5164b7b8ca39bb45bee789da44097052c882fa84996e4d90eec6fe8d3"
+  1.25.4:
+    url: https://github.com/mongodb/mongo-c-driver/archive/refs/tags/1.25.4.tar.gz
+    sha256: 0ab3c5b238803b82a6b217d1ef21ea71a6e96251063322dc1038bea70a3da541

--- a/recipes/mongo-c-driver/all/conanfile.py
+++ b/recipes/mongo-c-driver/all/conanfile.py
@@ -1,5 +1,6 @@
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
+from conan.tools.scm import Version
 import os
 
 
@@ -27,7 +28,7 @@ class MongoCDriverConan(ConanFile):
 
     def requirements(self):
         if self.settings.os == "Linux":
-            self.requires("openssl/3.0.7")
+            self.requires("openssl/3.2.0")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
@@ -68,6 +69,9 @@ class MongoCDriverConan(ConanFile):
 
         if self.settings.compiler == "Visual Studio":
             cmake.definitions["ENABLE_EXTRA_ALIGNMENT"] = "OFF"
+
+        if Version(self.version) >= "1.25.0":
+            cmake.definitions["BUILD_VERSION"] = str(self.version)
 
         cmake.configure(build_folder=self._build_subfolder)
         return cmake

--- a/recipes/mongo-cxx-driver/all/conandata.yml
+++ b/recipes/mongo-cxx-driver/all/conandata.yml
@@ -1,7 +1,4 @@
 sources:
-  "3.6.7":
-    url: https://github.com/mongodb/mongo-cxx-driver/archive/r3.6.7.tar.gz
-    sha256: a9244d3117d4029a2f039dece242eef10e34502e4600e2afa968ab53589e6de7
   "3.7.1":
     url: https://github.com/mongodb/mongo-cxx-driver/archive/r3.7.1.tar.gz
     sha256: 79f9ae3fbd960354127c8bfa3035e34df6fd436991f9298c53d60579e96552d9

--- a/recipes/rocksdb/all/conandata.yml
+++ b/recipes/rocksdb/all/conandata.yml
@@ -1,7 +1,4 @@
 sources:
-  "7.7.3":
-    url: https://github.com/facebook/rocksdb/archive/v7.7.3.tar.gz
-    sha256: b8ac9784a342b2e314c821f6d701148912215666ac5e9bdbccd93cf3767cb611
   "7.10.2":
     url: https://github.com/facebook/rocksdb/archive/v7.10.2.tar.gz
     sha256: 4619ae7308cd3d11cdd36f0bfad3fb03a1ad399ca333f192b77b6b95b08e2f78

--- a/recipes/rocksdb/all/conanfile.py
+++ b/recipes/rocksdb/all/conanfile.py
@@ -22,7 +22,6 @@ class RocksDB(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
-        "enable_sse": [False, "sse42", "avx2"],
 
         "use_rtti": [True, False],
         "with_gflags": [True, False],
@@ -36,7 +35,6 @@ class RocksDB(ConanFile):
     default_options = {
         "shared": True,
         "fPIC": True,
-        "enable_sse": "sse42",
 
         "use_rtti": True,
         "with_gflags": False,
@@ -89,18 +87,9 @@ class RocksDB(ConanFile):
         #cmake.definitions["ROCKSDB_DLL" ] = self.settings.os == "Windows" and self.options.shared
 
         cmake.definitions["USE_RTTI"] = self.options.use_rtti
-        if "arm" in str(self.settings.arch):
-            self.options.enable_sse = "False"
 
-        if self.options.enable_sse == "False":
-          cmake.definitions["PORTABLE"] = True
-          cmake.definitions["FORCE_SSE42"] = False
-        elif self.options.enable_sse == "sse42":
-          cmake.definitions["PORTABLE"] = True
-          cmake.definitions["FORCE_SSE42"] = True
-        elif self.options.enable_sse == "avx2":
-          cmake.definitions["PORTABLE"] = False
-          cmake.definitions["FORCE_SSE42"] = False
+        # sse was removed https://github.com/facebook/rocksdb/pull/11419
+        cmake.definitions["PORTABLE"] = "TRUE"
 
         cmake.definitions["WITH_NUMA"] = False
 

--- a/scripts/CatapultRecipeUpdater.py
+++ b/scripts/CatapultRecipeUpdater.py
@@ -116,13 +116,13 @@ class CatapultRecipesUpdater:
 		url = config['sources'][version]['url']
 		with tempfile.TemporaryDirectory() as tmpdir:
 			tmp_source_filepath = f'{tmpdir}/{recipe}.{version}.tar.gz'
-			dispatch_subprocess(['curl', '-LJ', url, '--output', f'{tmp_source_filepath}'])
-			output, _ = dispatch_subprocess(['sha256sum', f'{tmp_source_filepath}'], handle_error=True)
+			dispatch_subprocess(['curl', '-LJ', url, '--output', tmp_source_filepath])
+			output, _ = dispatch_subprocess(['sha256sum', tmp_source_filepath], handle_error=True)
 			config['sources'][version]['sha256'] = output.split(' ')[0]
 			with open(filepath, 'w') as output_file:
 				yaml.dump(config, output_file, sort_keys=False)
 
-	async def _update_recipe_files(self, recipe, versions, recipes_versions):
+	async def _update_recipe_files(self, recipe, versions):
 		update_recipe_files_descriptor = [
 			r'{recipe}/config.yml',
 			r'{recipe}/all/conandata.yml',
@@ -142,7 +142,7 @@ class CatapultRecipesUpdater:
 	async def update_recipes_version(self, recipes_versions):
 		print(f'updating recipes {recipes_versions}')
 		await asyncio.gather(*[
-			self._update_recipe_files(recipe, versions, recipes_versions) for recipe, versions in recipes_versions.items()
+			self._update_recipe_files(recipe, versions) for recipe, versions in recipes_versions.items()
 		])
 
 		self.recipe_helper.update_recipe_dependent_version(recipes_versions, self.source_path)

--- a/scripts/CatapultRecipeUpdater.py
+++ b/scripts/CatapultRecipeUpdater.py
@@ -160,7 +160,7 @@ class CatapultRecipesUpdater:
 	async def build_conan_package(self, recipes_versions):
 		await self._execute_conan_package_command(
 			recipes_versions,
-			lambda version, recipe_name: ['conan', 'create', '.', f'{version}@nemtech/stable', '--remote=nemtech']
+			lambda version, recipe_name: ['conan', 'create', '.', f'{version}@nemtech/stable', '--build=missing', '--remote=nemtech']
 		)
 
 	async def upload_conan_package(self, recipes_versions):

--- a/scripts/CatapultRecipeUpdater.py
+++ b/scripts/CatapultRecipeUpdater.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+
+import argparse
+import asyncio
+import re
+import semver
+import subprocess
+import tempfile
+import yaml
+from collections import ChainMap
+
+from aiohttp import ClientSession
+from pathlib import Path
+
+CONAN_NEMTECH_REMOTE = 'https://conan.symbol.dev/artifactory/api/conan/catapult'
+RECIPES_REPOSITORIES = {
+	'benchmark': 'google',
+	'mongo-c-driver': 'mongodb',
+	'mongo-cxx-driver': 'mongodb',
+	'libzmq': 'zeromq',
+	'cppzmq': 'zeromq',
+	'rocksdb': 'facebook'
+}
+RECIPES = RECIPES_REPOSITORIES.keys()
+
+
+def dispatch_subprocess(command_line, cwd=None, handle_error=True):
+	print(' '.join(command_line))
+	result = subprocess.run(command_line, check=False, cwd=cwd, capture_output=True)
+	if handle_error and 0 != result.returncode:
+		raise subprocess.SubprocessError(f'command failed with exit code {result.returncode}\n{result}')
+
+	output = result.stdout.decode('utf-8') if 0 == result.returncode else result.stderr.decode('utf-8')
+	if output:
+		print(output)
+
+	return output, result.returncode
+
+
+class CatapultRecipesUpdater:
+	def __init__(self, source_path):
+		self.source_path = Path(source_path).absolute()
+
+	@staticmethod
+	async def _initialize_conan():
+		dispatch_subprocess(['conan', 'config', 'init'])
+		dispatch_subprocess(['conan', 'config', 'set', 'general.revisions_enabled=1'])
+		dispatch_subprocess(['conan', 'profile', 'update', 'settings.compiler.libcxx=libstdc++11', 'default'])
+		dispatch_subprocess(['conan', 'remote', 'add', '--force', 'nemtech', CONAN_NEMTECH_REMOTE])
+
+	@staticmethod
+	async def _get_recipe_latest_version(owner, repo):
+		url = f'https://api.github.com/repos/{owner}/{repo}/releases/latest'
+		async with ClientSession(raise_for_status=True) as session:
+			async with session.get(url) as response:
+				response_json = await response.json()
+				if 200 != response.status:
+					raise Exception(f'failed to get latest release for {owner}/{repo} {response_json}')
+				return re.sub(r'[^\d\.]', '', response_json['tag_name'])
+
+	@staticmethod
+	async def _read_yaml_file(filepath):
+		with open(filepath, 'r') as file:
+			return yaml.safe_load(file)
+
+	async def _get_current_version(self, name):
+		recipe_config_filepath = self.source_path / f'{name}/config.yml'
+		config = await self._read_yaml_file(recipe_config_filepath)
+		return next(iter(config['versions'].keys()))
+
+	async def _get_update_if_available(self, recipe):
+		owner = RECIPES_REPOSITORIES[recipe]
+		recipe_update = {}
+		latest_version = await self._get_recipe_latest_version(owner, recipe)
+		recipe = 'zeromq' if 'libzmq' == recipe else recipe
+		current_version = await self._get_current_version(recipe)
+		print(f'checking recipe {recipe} {current_version} -> {latest_version}')
+		if semver.compare(latest_version, current_version) > 0:
+			print(f'{recipe} has new version: {latest_version}')
+			recipe_update[recipe] = (current_version, latest_version)
+
+		return recipe_update
+
+	async def get_available_update(self, recipes):
+		results = await asyncio.gather(*[self._get_update_if_available(recipe) for recipe in recipes])
+		recipe_with_updates = dict(ChainMap(*results))
+		return recipe_with_updates
+
+	async def _update_conandata_sha(self, recipe, filepath, version):
+		config = await self._read_yaml_file(filepath)
+		url = config['sources'][version]['url']
+		with tempfile.TemporaryDirectory() as tmpdir:
+			download_file = f'{tmpdir}/{recipe}.{version}.tar.gz'
+			dispatch_subprocess(['curl', '-LJ', url, '--output', f'{download_file}'])
+			output, _ = dispatch_subprocess(['sha256sum', f'{download_file}'], handle_error=True)
+			config['sources'][version]['sha256'] = output.split(' ')[0]
+			with open(filepath, 'w') as output_file:
+				yaml.dump(config, output_file, sort_keys=False)
+
+	async def _update_recipe_files(self, recipe, versions, recipes_versions):
+		update_recipe_files_descriptor = [
+			r'{recipe}/config.yml',
+			r'{recipe}/all/conandata.yml',
+			r'{recipe}/all/test_package/CMakeLists.txt',
+			r'{recipe}/all/conanfile.py',
+		]
+		dependency_map = {'mongo-cxx-driver': 'mongo-c-driver', 'cppzmq': 'zeromq'}
+
+		print(f'updating recipe {recipe} {versions}')
+		for recipe_file_descriptor in update_recipe_files_descriptor:
+			recipe_file = recipe_file_descriptor.format(recipe=recipe)
+			recipe_file_path = self.source_path / recipe_file
+			if recipe_file_path.exists():
+				if 'conanfile.py' == recipe_file_path.name:
+					if recipe not in dependency_map.keys():
+						continue
+
+					dependency_recipe = dependency_map[recipe]
+					if dependency_recipe not in recipes_versions.keys():
+						continue
+
+					current_version, new_version = recipes_versions[dependency_map[recipe]]
+				else:
+					current_version, new_version = versions
+
+				dispatch_subprocess(
+					['sed', '-i', f's/{current_version}/{new_version}/g', str(recipe_file_path)],
+					handle_error=True
+				)
+
+				if 'conandata.yml' == recipe_file_path.name:
+					await self._update_conandata_sha(recipe, recipe_file_path, new_version)
+
+	async def update_recipe_version(self, recipes_versions):
+		print(f'updating recipes {recipes_versions}')
+		await asyncio.gather(*[
+			self._update_recipe_files(recipe, versions, recipes_versions) for recipe, versions in recipes_versions.items()
+		])
+
+	async def build_conan_package(self, recipes_versions):
+		await self._initialize_conan()
+		for recipe, versions in recipes_versions.items():
+			_, new_version = versions
+			recipe_path = self.source_path / f'{recipe}/all'
+			dispatch_subprocess(
+				['conan', 'create', '.', f'{new_version}@nemtech/stable', '--remote=nemtech'],
+				cwd=recipe_path,
+				handle_error=True
+			)
+
+	async def upload_conan_package(self, recipes_versions):
+		for recipe, versions in recipes_versions:
+			_, new_version = versions
+			recipe_path = self.source_path / f'{recipe}/all'
+			dispatch_subprocess(
+				['conan', 'upload', f'{recipe}/{new_version}@nemtech/stable', '--remote=nemtech'],
+				cwd=recipe_path,
+				handle_error=True
+			)
+
+
+async def main():
+	parser = argparse.ArgumentParser(description='Recipes updater for catapult')
+	parser.add_argument('--commit-title', help='commit title')
+	parser.add_argument('--recipes', choices=RECIPES, help='recipes to update', default=RECIPES)
+	parser.add_argument('--recipes-path', help='path to the recipes', required=True)
+	parser.add_argument('--upload', help='upload recipes to conan', action='store_true')
+	args = parser.parse_args()
+
+	recipes_updater = CatapultRecipesUpdater(args.recipes_path)
+	recipes_to_update = await recipes_updater.get_available_update(args.recipes)
+	if not recipes_to_update:
+		print('no recipe to update')
+		return
+
+	print(f'recipes to update - {recipes_to_update}')
+	await recipes_updater.update_recipe_version(recipes_to_update)
+	await recipes_updater.build_conan_package(recipes_to_update)
+
+	if args.upload:
+		await recipes_updater.upload_conan_package(recipes_to_update)
+
+	update_message = '\n'.join([f'{recipe} {versions[0]} -> {versions[1]}' for recipe, versions in recipes_to_update.items()])
+	print(f'updated recipe:\n{update_message}')
+	if args.commit_title:
+		dispatch_subprocess(['git', 'add', '.'])
+		dispatch_subprocess(['git', 'commit', '-m', f'{args.commit_title}\n\n{update_message}'])
+
+
+if '__main__' == __name__:
+	asyncio.run(main())

--- a/scripts/CatapultRecipeUpdater.py
+++ b/scripts/CatapultRecipeUpdater.py
@@ -187,17 +187,20 @@ async def main():
 
 	print(f'recipes to update - {recipes_to_update}')
 	await recipes_updater.update_recipes_version(recipes_to_update)
+	update_message = '\n'.join([f'{recipe} {versions[0]} -> {versions[1]}' for recipe, versions in recipes_to_update.items()])
+
+	# commit recipe updates before doing the build.
+	if args.commit_title:
+		dispatch_subprocess(['git', 'add', '.'])
+		dispatch_subprocess(['git', 'commit', '-m', f'{args.commit_title}\n\n{update_message}'])
+
 	initialize_conan()
 	await recipes_updater.build_conan_package(recipes_to_update)
 
 	if args.upload:
 		await recipes_updater.upload_conan_package(recipes_to_update)
 
-	update_message = '\n'.join([f'{recipe} {versions[0]} -> {versions[1]}' for recipe, versions in recipes_to_update.items()])
 	print(f'updated recipe:\n{update_message}')
-	if args.commit_title:
-		dispatch_subprocess(['git', 'add', '.'])
-		dispatch_subprocess(['git', 'commit', '-m', f'{args.commit_title}\n\n{update_message}'])
 
 
 if '__main__' == __name__:

--- a/scripts/CatapultRecipeUpdater.py
+++ b/scripts/CatapultRecipeUpdater.py
@@ -7,7 +7,6 @@ import semver
 import subprocess
 import tempfile
 import yaml
-from collections import ChainMap
 
 from aiohttp import ClientSession
 from pathlib import Path
@@ -22,6 +21,8 @@ RECIPES_REPOSITORIES = {
 	'rocksdb': 'facebook'
 }
 RECIPES = RECIPES_REPOSITORIES.keys()
+DEPENDENCY_MAP = {'mongo-cxx-driver': 'mongo-c-driver', 'cppzmq': 'zeromq'}
+REPO_RECIPE_MAP = {'libzmq': 'zeromq'}
 
 
 def dispatch_subprocess(command_line, cwd=None, handle_error=True):
@@ -30,23 +31,49 @@ def dispatch_subprocess(command_line, cwd=None, handle_error=True):
 	if handle_error and 0 != result.returncode:
 		raise subprocess.SubprocessError(f'command failed with exit code {result.returncode}\n{result}')
 
-	output = result.stdout.decode('utf-8') if 0 == result.returncode else result.stderr.decode('utf-8')
-	if output:
-		print(output)
+	output = result.stdout if 0 == result.returncode else result.stderr
+	decode_output = output.decode('utf-8')
+	if decode_output:
+		print(decode_output)
 
-	return output, result.returncode
+	return decode_output, result.returncode
+
+
+def update_recipe_version(current_version, new_version, filepath):
+	dispatch_subprocess(
+		['sed', '-i', f's/{current_version}/{new_version}/g', str(filepath)],
+		handle_error=True
+	)
+
+
+def initialize_conan():
+	dispatch_subprocess(['conan', 'config', 'init'])
+	dispatch_subprocess(['conan', 'config', 'set', 'general.revisions_enabled=1'])
+	dispatch_subprocess(['conan', 'profile', 'update', 'settings.compiler.libcxx=libstdc++11', 'default'])
+	dispatch_subprocess(['conan', 'remote', 'add', '--force', 'nemtech', CONAN_NEMTECH_REMOTE])
+
+
+class RecipeHelper:
+	def __init__(self, dependency_map, repo_recipe_map):
+		self.dependency_map = dependency_map
+		self.repo_recipe_map = repo_recipe_map
+
+	def update_recipe_dependent_version(self, recipes_versions, recipe_path):
+		for recipe, recipe_dependent in self.dependency_map.items():
+			versions = recipes_versions.get(recipe_dependent)
+			print(f'checking dependent version {recipe}, {recipe_dependent} {versions}')
+			if versions:
+				current_version, new_version = versions
+				update_recipe_version(current_version, new_version, recipe_path / f'{recipe}/all/conanfile.py')
+
+	def get_recipe_name(self, repo_name):
+		return self.repo_recipe_map.get(repo_name, repo_name)
 
 
 class CatapultRecipesUpdater:
-	def __init__(self, source_path):
+	def __init__(self, source_path, recipe_helper):
 		self.source_path = Path(source_path).absolute()
-
-	@staticmethod
-	async def _initialize_conan():
-		dispatch_subprocess(['conan', 'config', 'init'])
-		dispatch_subprocess(['conan', 'config', 'set', 'general.revisions_enabled=1'])
-		dispatch_subprocess(['conan', 'profile', 'update', 'settings.compiler.libcxx=libstdc++11', 'default'])
-		dispatch_subprocess(['conan', 'remote', 'add', '--force', 'nemtech', CONAN_NEMTECH_REMOTE])
+		self.recipe_helper = recipe_helper
 
 	@staticmethod
 	async def _get_recipe_latest_version(owner, repo):
@@ -60,7 +87,7 @@ class CatapultRecipesUpdater:
 
 	@staticmethod
 	async def _read_yaml_file(filepath):
-		with open(filepath, 'r') as file:
+		with open(filepath, 'rt') as file:
 			return yaml.safe_load(file)
 
 	async def _get_current_version(self, name):
@@ -68,31 +95,29 @@ class CatapultRecipesUpdater:
 		config = await self._read_yaml_file(recipe_config_filepath)
 		return next(iter(config['versions'].keys()))
 
-	async def _get_update_if_available(self, recipe):
-		owner = RECIPES_REPOSITORIES[recipe]
-		recipe_update = {}
-		latest_version = await self._get_recipe_latest_version(owner, recipe)
-		recipe = 'zeromq' if 'libzmq' == recipe else recipe
+	async def _get_update_if_available(self, recipe_repo):
+		owner = RECIPES_REPOSITORIES[recipe_repo]
+		latest_version = await self._get_recipe_latest_version(owner, recipe_repo)
+		recipe = self.recipe_helper.get_recipe_name(recipe_repo)
 		current_version = await self._get_current_version(recipe)
 		print(f'checking recipe {recipe} {current_version} -> {latest_version}')
 		if semver.compare(latest_version, current_version) > 0:
 			print(f'{recipe} has new version: {latest_version}')
-			recipe_update[recipe] = (current_version, latest_version)
+			return recipe, current_version, latest_version
 
-		return recipe_update
+		return None
 
-	async def get_available_update(self, recipes):
+	async def get_available_updates(self, recipes):
 		results = await asyncio.gather(*[self._get_update_if_available(recipe) for recipe in recipes])
-		recipe_with_updates = dict(ChainMap(*results))
-		return recipe_with_updates
+		return {result[0]: (result[1], result[2]) for result in results if result}
 
 	async def _update_conandata_sha(self, recipe, filepath, version):
 		config = await self._read_yaml_file(filepath)
 		url = config['sources'][version]['url']
 		with tempfile.TemporaryDirectory() as tmpdir:
-			download_file = f'{tmpdir}/{recipe}.{version}.tar.gz'
-			dispatch_subprocess(['curl', '-LJ', url, '--output', f'{download_file}'])
-			output, _ = dispatch_subprocess(['sha256sum', f'{download_file}'], handle_error=True)
+			tmp_source_filepath = f'{tmpdir}/{recipe}.{version}.tar.gz'
+			dispatch_subprocess(['curl', '-LJ', url, '--output', f'{tmp_source_filepath}'])
+			output, _ = dispatch_subprocess(['sha256sum', f'{tmp_source_filepath}'], handle_error=True)
 			config['sources'][version]['sha256'] = output.split(' ')[0]
 			with open(filepath, 'w') as output_file:
 				yaml.dump(config, output_file, sort_keys=False)
@@ -102,61 +127,47 @@ class CatapultRecipesUpdater:
 			r'{recipe}/config.yml',
 			r'{recipe}/all/conandata.yml',
 			r'{recipe}/all/test_package/CMakeLists.txt',
-			r'{recipe}/all/conanfile.py',
 		]
-		dependency_map = {'mongo-cxx-driver': 'mongo-c-driver', 'cppzmq': 'zeromq'}
 
 		print(f'updating recipe {recipe} {versions}')
 		for recipe_file_descriptor in update_recipe_files_descriptor:
 			recipe_file = recipe_file_descriptor.format(recipe=recipe)
-			recipe_file_path = self.source_path / recipe_file
-			if recipe_file_path.exists():
-				if 'conanfile.py' == recipe_file_path.name:
-					if recipe not in dependency_map.keys():
-						continue
+			recipe_filepath = self.source_path / recipe_file
+			if recipe_filepath.exists():
+				current_version, new_version = versions
+				update_recipe_version(current_version, new_version, recipe_filepath)
+				if 'conandata.yml' == recipe_filepath.name:
+					await self._update_conandata_sha(recipe, recipe_filepath, new_version)
 
-					dependency_recipe = dependency_map[recipe]
-					if dependency_recipe not in recipes_versions.keys():
-						continue
-
-					current_version, new_version = recipes_versions[dependency_map[recipe]]
-				else:
-					current_version, new_version = versions
-
-				dispatch_subprocess(
-					['sed', '-i', f's/{current_version}/{new_version}/g', str(recipe_file_path)],
-					handle_error=True
-				)
-
-				if 'conandata.yml' == recipe_file_path.name:
-					await self._update_conandata_sha(recipe, recipe_file_path, new_version)
-
-	async def update_recipe_version(self, recipes_versions):
+	async def update_recipes_version(self, recipes_versions):
 		print(f'updating recipes {recipes_versions}')
 		await asyncio.gather(*[
 			self._update_recipe_files(recipe, versions, recipes_versions) for recipe, versions in recipes_versions.items()
 		])
 
-	async def build_conan_package(self, recipes_versions):
-		await self._initialize_conan()
+		self.recipe_helper.update_recipe_dependent_version(recipes_versions, self.source_path)
+
+	async def _execute_conan_package_command(self, recipes_versions, get_command):
 		for recipe, versions in recipes_versions.items():
 			_, new_version = versions
 			recipe_path = self.source_path / f'{recipe}/all'
 			dispatch_subprocess(
-				['conan', 'create', '.', f'{new_version}@nemtech/stable', '--remote=nemtech'],
+				get_command(new_version, recipe),
 				cwd=recipe_path,
 				handle_error=True
 			)
 
+	async def build_conan_package(self, recipes_versions):
+		await self._execute_conan_package_command(
+			recipes_versions,
+			lambda version, recipe_name: ['conan', 'create', '.', f'{version}@nemtech/stable', '--remote=nemtech']
+		)
+
 	async def upload_conan_package(self, recipes_versions):
-		for recipe, versions in recipes_versions:
-			_, new_version = versions
-			recipe_path = self.source_path / f'{recipe}/all'
-			dispatch_subprocess(
-				['conan', 'upload', f'{recipe}/{new_version}@nemtech/stable', '--remote=nemtech'],
-				cwd=recipe_path,
-				handle_error=True
-			)
+		await self._execute_conan_package_command(
+			recipes_versions,
+			lambda version, recipe_name: ['conan', 'upload', f'{recipe_name}/{version}@nemtech/stable', '--remote=nemtech']
+		)
 
 
 async def main():
@@ -167,14 +178,16 @@ async def main():
 	parser.add_argument('--upload', help='upload recipes to conan', action='store_true')
 	args = parser.parse_args()
 
-	recipes_updater = CatapultRecipesUpdater(args.recipes_path)
-	recipes_to_update = await recipes_updater.get_available_update(args.recipes)
+	recipe_helper = RecipeHelper(DEPENDENCY_MAP, REPO_RECIPE_MAP)
+	recipes_updater = CatapultRecipesUpdater(args.recipes_path, recipe_helper)
+	recipes_to_update = await recipes_updater.get_available_updates(args.recipes)
 	if not recipes_to_update:
 		print('no recipe to update')
 		return
 
 	print(f'recipes to update - {recipes_to_update}')
-	await recipes_updater.update_recipe_version(recipes_to_update)
+	await recipes_updater.update_recipes_version(recipes_to_update)
+	initialize_conan()
 	await recipes_updater.build_conan_package(recipes_to_update)
 
 	if args.upload:

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,3 @@
+aiohttp==3.9.1
+pyyaml==6.0.1
+semver==3.0.2


### PR DESCRIPTION
problem: currently recipes are updated manually
solution: create Jenkins to update the recipes

Fix build issue with RocksDB and mongo-c-driver.
Will need to build the packages and tests with the catapult client.