### PR TITLE
[recipes] fix: mongo-cxx-driver libraries name change in 3.10

### DIFF
--- a/recipes/mongo-cxx-driver/all/conanfile.py
+++ b/recipes/mongo-cxx-driver/all/conanfile.py
@@ -47,6 +47,9 @@ class MongoCxxConan(ConanFile):
 		if is_msvc(self):
 			tc.cache_variables["CMAKE_CXX_FLAGS"] = "/Zc:__cplusplus /EHsc"
 
+		if Version(self.version) >= "3.10.0" and is_msvc(self):
+			tc.variables["ENABLE_ABI_TAG_IN_LIBRARY_FILENAMES"] = False
+
 		if "Macos" == self.settings.os:
 			tc.blocks["rpath"].skip_rpath = False
 


### PR DESCRIPTION
problem: starting with mongocxx 3.10.0 MSVC toolchain on Windows generates different library names
solution: disable this feature by setting ENABLE_ABI_TAG_IN_LIBRARY_FILENAMES=OFF

https://www.mongodb.com/docs/languages/cpp/cpp-driver/upcoming/api-abi-versioning/#shared-libraries--msvc-only-