### PR TITLE
[recipes] fix: build fail to find openssl

### DIFF
--- a/scripts/CatapultRecipeUpdater.py
+++ b/scripts/CatapultRecipeUpdater.py
@@ -157,7 +157,7 @@ class CatapultRecipesUpdater:
 	async def build_conan_package(self, recipes_versions):
 		await self._execute_conan_package_command(
 			recipes_versions,
-			lambda version, recipe_name: ['conan', 'create', '.', f'--name={recipe_name}', f'--version={version}', '--user=nemtech', '--channel=stable', '--build=missing', '--remote=nemtech']
+			lambda version, recipe_name: ['conan', 'create', '.', f'--name={recipe_name}', f'--version={version}', '--user=nemtech', '--channel=stable', '--build=missing']
 		)
 
 	async def upload_conan_package(self, recipes_versions):

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,3 +1,3 @@
-aiohttp==3.9.1
-pyyaml==6.0.1
-conan==2.1.0
+aiohttp==3.11.16
+pyyaml==6.0.2
+conan==2.15.1


### PR DESCRIPTION
problem: latest version of conan as new download url
         conan now only checks remotes specify on the comnand line.
solution: update to the latest conan version
          remove the remote param from the conan create