### PR TITLE
[recipe] fix: relax MongoDB C driver requirement in MongoDB CXX

### DIFF
--- a/recipes/mongo-cxx-driver/all/conanfile.py
+++ b/recipes/mongo-cxx-driver/all/conanfile.py
@@ -20,7 +20,7 @@ class MongoCxxConan(ConanFile):
 	default_options = {"shared": True}
 
 	def requirements(self):
-		self.requires("mongo-c-driver/1.30.3@nemtech/stable", transitive_libs=True, run=True)
+		self.requires("mongo-c-driver/[>=1.30 <2.0]@nemtech/stable", transitive_libs=True, run=True)
 
 	def layout(self):
 		cmake_layout(self, src_folder="src")


### PR DESCRIPTION
relax MongoDB C driver requirement in MongoDB CXX.  Could probably just remove it but this will be a safe guard since MongoDB CXX v4 only support a specific C Driver.